### PR TITLE
Fix guild table init

### DIFF
--- a/otter_welcome_buddy/__main__.py
+++ b/otter_welcome_buddy/__main__.py
@@ -25,13 +25,14 @@ async def main() -> None:
     """Principal function to be called by Docker"""
     _setup()
 
+    database.init_database()
+
     bot: Bot = Bot(
         command_prefix=when_mentioned_or(COMMAND_PREFIX),
         intents=intents.get_registered_intents(),
     )
 
     async with bot:
-        await database.init_database(bot)
         await cogs.register_cogs(bot)
         await bot.start(os.environ["DISCORD_TOKEN"])
 

--- a/otter_welcome_buddy/cogs/events.py
+++ b/otter_welcome_buddy/cogs/events.py
@@ -8,6 +8,7 @@ from otter_welcome_buddy.database.dbconn import session_scope
 from otter_welcome_buddy.database.models.guild_model import GuildModel
 from otter_welcome_buddy.formatters import debug
 from otter_welcome_buddy.settings import WELCOME_MESSAGES
+from otter_welcome_buddy.startup.database import init_guild_table
 
 
 class BotEvents(commands.Cog):
@@ -24,22 +25,24 @@ class BotEvents(commands.Cog):
     @commands.Cog.listener()
     async def on_ready(self) -> None:
         """Ready Event"""
+        init_guild_table(self.bot)
+
         print(self.debug_formatter.bot_is_ready())
 
     @commands.Cog.listener()
     async def on_guild_join(self, guild: discord.Guild) -> None:
         """Event fired when a guild is either created or the bot join into"""
+        print(f"Bot joined into guild {guild.name} [{guild.id}]")
         with session_scope() as session:
-            if DbGuild.get_guild(guild_id=guild.id, session=session) is None:
-                guild_model = GuildModel(id=guild.id)
-                DbGuild.insert_guild(guild_model=guild_model, session=session)
+            guild_model = GuildModel(id=guild.id)
+            DbGuild.insert_guild(guild_model=guild_model, session=session)
 
     @commands.Cog.listener()
     async def on_guild_remove(self, guild: discord.Guild) -> None:
         """Event fired when a guild is deleted or the bot is removed from it"""
+        print(f"Bot removed from guild {guild.name} [{guild.id}]")
         with session_scope() as session:
-            if DbGuild.get_guild(guild_id=guild.id, session=session) is not None:
-                DbGuild.delete_guild(guild_id=guild.id, session=session)
+            DbGuild.delete_guild(guild_id=guild.id, session=session)
 
     @commands.Cog.listener()
     async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent) -> None:

--- a/otter_welcome_buddy/database/db_guild.py
+++ b/otter_welcome_buddy/database/db_guild.py
@@ -21,8 +21,15 @@ class DbGuild:
     def insert_guild(
         guild_model: GuildModel,
         session: Session,
+        override: bool = False,
     ) -> GuildModel:
         """Static method to insert a guild record"""
+        if not override:
+            current_guild_model = DbGuild.get_guild(guild_id=guild_model.id, session=session)
+            if current_guild_model is None:
+                session.add(guild_model)
+                return guild_model
+            return current_guild_model
         guild_model = session.merge(guild_model)
         return guild_model
 

--- a/otter_welcome_buddy/database/db_guild.py
+++ b/otter_welcome_buddy/database/db_guild.py
@@ -38,5 +38,5 @@ class DbGuild:
         guild_id: int,
         session: Session,
     ) -> None:
-        """Static method to delete an interview match record by a guild_id"""
-        session.query(GuildModel).filter_by(guild_id=guild_id).delete()
+        """Static method to delete a guild record by its id"""
+        session.query(GuildModel).filter_by(id=guild_id).delete()

--- a/otter_welcome_buddy/startup/database.py
+++ b/otter_welcome_buddy/startup/database.py
@@ -8,14 +8,16 @@ from otter_welcome_buddy.database.dbconn import session_scope
 from otter_welcome_buddy.database.models.guild_model import GuildModel
 
 
-async def init_database(bot: Bot) -> None:
+def init_guild_table(bot: Bot) -> None:
+    """Verify that all the guilds that the bot is part of are in the database"""
+    for guild in bot.guilds:
+        print(f"Initializing guild {guild.name} [{guild.id}]")
+        with session_scope() as session:
+            guild_model = GuildModel(id=guild.id)
+            DbGuild.insert_guild(guild_model=guild_model, session=session)
+
+
+def init_database() -> None:
     """Initialize the database from the existing models"""
     engine = get_engine(db_path=DATA_FILE_PATH)
     BaseModel.metadata.create_all(engine)
-
-    # Verify that all the guilds that the bot is part of are in the database
-    for guild in bot.guilds:
-        with session_scope() as session:
-            if DbGuild.get_guild(guild_id=guild.id, session=session) is None:
-                guild_model = GuildModel(id=guild.id)
-                DbGuild.insert_guild(guild_model=guild_model, session=session)

--- a/tests/cogs/test_events.py
+++ b/tests/cogs/test_events.py
@@ -13,7 +13,6 @@ from pytest_mock import MockFixture
 
 from otter_welcome_buddy.cogs import events
 from otter_welcome_buddy.database.db_guild import DbGuild
-from otter_welcome_buddy.database.models.guild_model import GuildModel
 
 if TYPE_CHECKING:
     from discord.types.gateway import MessageReactionAddEvent
@@ -39,7 +38,7 @@ async def test_onReady_printMessage(
 ):
     # Arrange
     cog = events.BotEvents(mock_bot, mock_debug_fmt)
-    
+
     mock_init_guild = mocker.patch("otter_welcome_buddy.cogs.events.init_guild_table")
 
     # Act

--- a/tests/startup/test_database.py
+++ b/tests/startup/test_database.py
@@ -1,13 +1,12 @@
-from typing import Callable
-from unittest.mock import MagicMock, patch
-
-from discord.ext.commands import Bot
+from unittest.mock import MagicMock
+from unittest.mock import patch
 
 from pytest_mock import MockFixture
+
 from otter_welcome_buddy.startup import database
 
 
-@patch('otter_welcome_buddy.startup.database.BaseModel.metadata.create_all')
+@patch("otter_welcome_buddy.startup.database.BaseModel.metadata.create_all")
 def test_initDatabase(mock_create_all: MagicMock, mocker: MockFixture):
     # Arrange
     mock_engine = MagicMock()

--- a/tests/startup/test_database.py
+++ b/tests/startup/test_database.py
@@ -1,0 +1,26 @@
+from typing import Callable
+from unittest.mock import MagicMock, patch
+
+from discord.ext.commands import Bot
+
+from pytest_mock import MockFixture
+from otter_welcome_buddy.startup import database
+
+
+@patch('otter_welcome_buddy.startup.database.BaseModel.metadata.create_all')
+def test_initDatabase(mock_create_all: MagicMock, mocker: MockFixture):
+    # Arrange
+    mock_engine = MagicMock()
+
+    mock_get_engine = mocker.patch(
+        "otter_welcome_buddy.startup.database.get_engine",
+        return_value=mock_engine,
+    )
+
+    # Act
+    database.init_database()
+
+    # Assert
+    print(type(mock_create_all))
+    mock_get_engine.assert_called_once()
+    mock_create_all.assert_called_once_with(mock_engine)


### PR DESCRIPTION
# Description

Fix logic when initializing the guild table, we should wait to the bot to be ready to be able to access to its guilds.

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

Local testing along with some unit tests added

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
