### PR TITLE
English Club feature implementation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 default_language_version:
   # force all unspecified python hooks to run python3
-  python: python3
+  python: python3.10
 
 repos:
   - repo: https://github.com/asottile/pyupgrade

--- a/otter_welcome_buddy/cogs/englishclub_reminder.py
+++ b/otter_welcome_buddy/cogs/englishclub_reminder.py
@@ -3,13 +3,13 @@ import re
 
 import discord
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
-from discord import Embed
 from discord import TextChannel
 from discord.ext import commands
 from discord.ext.commands import Bot
 from discord.ext.commands import Context
 
 from otter_welcome_buddy.common.constants import CronExpressions
+from otter_welcome_buddy.common.discord_channel import DiscordChannel
 from otter_welcome_buddy.common.utils.dates import DateUtils
 from otter_welcome_buddy.common.utils.types.common import DiscordChannelType
 from otter_welcome_buddy.formatters import englishclub_message
@@ -43,6 +43,7 @@ class English(commands.Cog):
         invoke_without_command=True,
         pass_context=True,
     )
+    @commands.check(is_allowed)
     async def englishclub(self, ctx: Context) -> None:
         """
         English Club will setup an English session
@@ -50,11 +51,13 @@ class English(commands.Cog):
         await ctx.send_help(ctx.command)
 
     @englishclub.command(brief="Start the cronjob for the messages")  # type: ignore
+    @commands.check(is_allowed)
     async def start(self, _: Context) -> None:
         """Command to interact with the bot and start cron"""
         self.__configure_scheduler()
 
     @englishclub.command(brief="Stop the cronjob for the messages")  # type: ignore
+    @commands.check(is_allowed)
     async def stop(self, _: Context) -> None:
         """Command to interact with the bot and stop cron"""
         self.scheduler.remove_job("job_id")
@@ -64,43 +67,50 @@ class English(commands.Cog):
     async def schedule_session(self, ctx: Context, hour: str) -> None:
         """Schedule the English Club session"""
 
-        pattern = r"^\d{1,2}:\d{2}(AM|PM)$"
+        # Regex pattern explanation:
+        # ^: Asserts the start of the string.
+        # \d{1,2}: Matches 1 or 2 digits, representing the hour (e.g., 1, 10, or 12).
+        # : Matches the colon that separates the hour and minute.
+        # \d{2}: Matches exactly 2 digits, representing the minutes (e.g., 00, 30, or 59).
+        # (AM|PM): Matches either "AM" or "PM" (case-sensitive).
+        # $: Asserts the end of the string.
+        time_format_regex = r"^\d{1,2}:\d{2}(AM|PM)$"
 
-        if re.match(pattern, hour):
-            channel_id: int = int(os.environ["ENGLISH_CHANNEL_ID"])
-            channel: DiscordChannelType | None = self.bot.get_channel(channel_id)
+        if re.match(time_format_regex, hour):
+            channel_id: int = DiscordChannel.ENGLISH_CHANNEL_ID.value
+            channel: DiscordChannelType | None = (
+                DiscordChannel.ENGLISH_CHANNEL_ID.get_discord_channel(
+                    self.bot,
+                    channel_id,
+                )
+            )
             mention = "@everyone"
 
             embed = discord.Embed(
-                colour=discord.Colour.blue(),
+                colour=discord.Colour.green(),
                 title="English Club session",
                 description=mention + self.messages_formatter.english_club_message(hour),
             )
 
-            embed.set_image(url="https://shorturl.at/blqMV")
+            embed.set_image(url=DiscordChannel.ENGLISH_CHANNEL_IMAGE.value)
 
             if isinstance(channel, TextChannel):
                 await channel.send(embed=embed)
         else:
             await ctx.send(
-                "Invalid, Use the following format: HH:MMam or HH:MMpm, e.g., '10:00PM'.",
+                "Invalid, Use the following format: HH:MMAM or HH:MMPM, e.g., '10:00PM'.",
             )
 
-    def message_non_english_club(self) -> Embed:
+    def message_non_english_club(self) -> str:
         """
         Generate an Embed message for the English Club reminder.
         """
 
         user_1 = f"<@{os.environ['USER_ONE_ID']}>"
         user_2 = f"<@{os.environ['USER_TWO_ID']}>"
+        description = f"{self.messages_formatter.non_english_club_message()} {user_1} {user_2} 👀"
 
-        embed = discord.Embed(
-            colour=discord.Colour.blue(),
-            title="English Club Reminder",
-            description=f"{self.messages_formatter.non_english_club_message()} {user_1} {user_2} 👀",
-        )
-
-        return embed
+        return description
 
     def __configure_scheduler(self) -> None:
         """Configure and start scheduler"""
@@ -108,7 +118,7 @@ class English(commands.Cog):
         self.scheduler.add_job(
             self.send_message_on_english_non_teachers,
             DateUtils.create_cron_trigger_from(
-                CronExpressions.ENGLISH_CLUB_TIME.value,
+                CronExpressions.NON_ENGLISH_TEACHERS_MESSAGE_TIME.value,
             ),
             id="job_id",
         )
@@ -119,10 +129,15 @@ class English(commands.Cog):
         Sends message to english_non_teachers channel
         """
 
-        channel_id: int = int(os.environ["ROOT_CHANNEL_ID"])
-        channel: DiscordChannelType | None = self.bot.get_channel(channel_id)
+        channel_id: int = DiscordChannel.NON_ENGLISH_TEACHERS_CHANNEL_ID.value
+        channel: DiscordChannelType | None = (
+            DiscordChannel.NON_ENGLISH_TEACHERS_CHANNEL_ID.get_discord_channel(
+                self.bot,
+                channel_id,
+            )
+        )
         if isinstance(channel, TextChannel):
-            await channel.send(embed=self.message_non_english_club())
+            await channel.send(self.message_non_english_club())
         else:
             raise TypeError("Not valid channel to send the message in")
 

--- a/otter_welcome_buddy/cogs/englishclub_reminder.py
+++ b/otter_welcome_buddy/cogs/englishclub_reminder.py
@@ -57,7 +57,7 @@ class English(commands.Cog):
     @englishclub.command(brief="Stop the cronjob for the messages")  # type: ignore
     async def stop(self, _: Context) -> None:
         """Command to interact with the bot and stop cron"""
-        self.scheduler.stop()
+        self.scheduler.remove_job("job_id")
 
     @commands.command(brief="Schedule an English session")
     @commands.check(is_allowed)
@@ -110,6 +110,7 @@ class English(commands.Cog):
             DateUtils.create_cron_trigger_from(
                 CronExpressions.ENGLISH_CLUB_TIME.value,
             ),
+            id="job_id",
         )
         self.scheduler.start()
 

--- a/otter_welcome_buddy/cogs/englishclub_reminder.py
+++ b/otter_welcome_buddy/cogs/englishclub_reminder.py
@@ -1,0 +1,120 @@
+import os
+import re
+
+import discord
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from discord import Embed
+from discord import TextChannel
+from discord.ext import commands
+from discord.ext.commands import Bot
+from discord.ext.commands import Context
+
+from otter_welcome_buddy.common.constants import CronExpressions
+from otter_welcome_buddy.common.utils.dates import DateUtils
+from otter_welcome_buddy.common.utils.types.common import DiscordChannelType
+from otter_welcome_buddy.formatters import englishclub_message
+
+
+class English(commands.Cog):
+    """
+    English command events, where notifications about English sessions
+    Commands:
+        englishclub start:     Start cronjob for timeline messages
+        englishclub stop:      Stop cronjob for timeline messages
+    """
+
+    def __init__(self, bot: Bot, messages_dependency: type[englishclub_message.Formatter]):
+        self.bot: Bot = bot
+        self.messages_formatter: type[englishclub_message.Formatter] = messages_dependency
+        self.scheduler: AsyncIOScheduler = AsyncIOScheduler()
+        self.__configure_scheduler()
+
+    @commands.group(
+        brief="Commands related to English Club!",
+        invoke_without_command=True,
+        pass_context=True,
+    )
+    async def englishclub(self, ctx: Context) -> None:
+        """
+        English Club will setup an English session
+        """
+        await ctx.send_help(ctx.command)
+
+    @englishclub.command(brief="Start the cronjob for the timeline messages")  # type: ignore
+    async def start(self, _: Context) -> None:
+        """Command to interact with the bot and start cron"""
+        self.__configure_scheduler()
+
+    @englishclub.command(brief="Stop the cronjob for the timeline messages")  # type: ignore
+    async def stop(self, _: Context) -> None:
+        """Command to interact with the bot and stop cron"""
+        self.scheduler.stop()
+
+    @commands.command(brief="Schedule an English session")
+    async def schedule_session(self, ctx: Context, hour: str) -> None:
+        """Schedule the English Club session"""
+
+        pattern = r"^\d{1,2}:\d{2}(AM|PM)$"
+
+        if re.match(pattern, hour):
+            channel_id: int = int(os.environ["ENGLISH_CHANNEL_ID"])
+            channel: DiscordChannelType | None = self.bot.get_channel(channel_id)
+            description = f"A study session has been scheduled for {hour} on Sunday"
+
+            embed = discord.Embed(
+                colour=discord.Colour.green(),
+                title="Schedule the English Club session",
+                description=description,
+            )
+
+            embed.set_image(url="bit.ly/3rZuR6Y")
+
+            if isinstance(channel, TextChannel):
+                await channel.send(embed=embed)
+        else:
+            await ctx.send(
+                "Invalid, Use the following format: HH:MMam or HH:MMpm, e.g., '10:00PM'.",
+            )
+
+    def _command_message(self) -> Embed:
+        """
+        Generate an Embed message for the English Club reminder.
+        """
+        axssel_user_id = int(os.environ["USER_ID"])
+        axssel_mention = f"<@{axssel_user_id}>"
+
+        embed = discord.Embed(
+            colour=discord.Colour.blue(),
+            title="English Club Reminder",
+            description=f"Hey yo, English club this week? {axssel_mention} 👀",
+        )
+
+        return embed
+
+    def __configure_scheduler(self) -> None:
+        """Configure and start scheduler"""
+
+        self.scheduler.add_job(
+            self.send_message_on_english_non_teachers,
+            DateUtils.create_cron_trigger_from(
+                CronExpressions.ENGLISH_CLUB_TIME.value,
+            ),
+        )
+        self.scheduler.start()
+
+    async def send_message_on_english_non_teachers(self) -> None:
+        """
+        Sends message to english_non_teachers channel
+        """
+
+        channel_id: int = int(os.environ["ROOT_CHANNEL_ID"])
+        channel: DiscordChannelType | None = self.bot.get_channel(channel_id)
+        if isinstance(channel, TextChannel):
+            await channel.send(embed=self._command_message())
+        else:
+            raise TypeError("Not valid channel to send the message in")
+
+
+async def setup(bot: Bot) -> None:
+    """Set up"""
+    await bot.add_cog(English(bot, englishclub_message.Formatter))

--- a/otter_welcome_buddy/cogs/hiring_timelines.py
+++ b/otter_welcome_buddy/cogs/hiring_timelines.py
@@ -47,7 +47,6 @@ class Timelines(commands.Cog):
         """Command to interact with the bot and stop cron"""
         self.scheduler.stop()
 
-
     def __configure_scheduler(self) -> None:
         """Configure and start scheduler"""
         self.scheduler.add_job(

--- a/otter_welcome_buddy/common/constants.py
+++ b/otter_welcome_buddy/common/constants.py
@@ -5,8 +5,7 @@ class CronExpressions(Enum):
     """Defined Cron Expressions"""
 
     DAY_ONE_OF_EACH_MONTH_CRON: str = "0 0 1 * *"
-    # ENGLISH_CLUB_TIME: str = "2 20 * * 4"
-    ENGLISH_CLUB_TIME: str = "* * * * *"
+    NON_ENGLISH_TEACHERS_MESSAGE_TIME: str = "0 13 * * 2"  # 12:00 PM Pacific Time
 
 
 COMMAND_PREFIX: str = "!"

--- a/otter_welcome_buddy/common/constants.py
+++ b/otter_welcome_buddy/common/constants.py
@@ -5,6 +5,8 @@ class CronExpressions(Enum):
     """Defined Cron Expressions"""
 
     DAY_ONE_OF_EACH_MONTH_CRON: str = "0 0 1 * *"
+    # ENGLISH_CLUB_TIME: str = "2 20 * * 4"
+    ENGLISH_CLUB_TIME: str = "* * * * *"
 
 
 COMMAND_PREFIX: str = "!"

--- a/otter_welcome_buddy/common/discord_channel.py
+++ b/otter_welcome_buddy/common/discord_channel.py
@@ -1,0 +1,25 @@
+import os
+from enum import Enum
+
+from discord.ext.commands import Bot
+from dotenv import load_dotenv
+
+from otter_welcome_buddy.common.utils.types.common import DiscordChannelType
+
+load_dotenv()
+
+
+class DiscordChannel(Enum):
+    """
+    Enum to store Discord channels variables
+    """
+
+    ENGLISH_CHANNEL_ID = int(os.environ["GENERAL_CHANNEL_ID"])
+    NON_ENGLISH_TEACHERS_CHANNEL_ID = int(os.environ["ROOT_CHANNEL_ID"])
+    ENGLISH_CHANNEL_IMAGE = "https://shorturl.at/blqMV"
+
+    def get_discord_channel(self, bot: Bot, channel_id: int) -> DiscordChannelType | None:
+        """
+        Function to get the a channel by ID
+        """
+        return bot.get_channel(channel_id) if channel_id else None

--- a/otter_welcome_buddy/common/utils/dates.py
+++ b/otter_welcome_buddy/common/utils/dates.py
@@ -14,4 +14,4 @@ class DateUtils:
     @staticmethod
     def create_cron_trigger_from(crontab: str) -> CronTrigger:
         """Returns cron trigger from crontab"""
-        return CronTrigger.from_crontab(crontab)
+        return CronTrigger.from_crontab(crontab, "America/Mexico_City")

--- a/otter_welcome_buddy/formatters/englishclub_message.py
+++ b/otter_welcome_buddy/formatters/englishclub_message.py
@@ -2,6 +2,22 @@ class Formatter:
     """Dependency to inject messages"""
 
     @staticmethod
-    def club_message() -> str:
-        """Message when a new user joins the discord"""
-        return "Hey yo, English club this week? 👀"
+    def non_english_club_message() -> str:
+        """Message ask English session"""
+        return "Hey yo, English club this week? "
+
+    @staticmethod
+    def english_club_message(hour: str) -> str:
+        """Message when an English session has been scheduled"""
+        message = f"""
+        📣 Join us for an exciting English Club session next Sunday at {hour} Pacific Time! 🕗🌟
+        📚 Let's dive into the world of English language and culture together.
+        It's a fantastic opportunity to practice your English skills and make new friends.
+
+        🗓️ Mark your calendars and set a reminder to join us. Don't miss out on the chance
+        to improve your language skills and connect with fellow language enthusiasts!
+
+        See you there! 🙌🇺🇸
+        """
+
+        return message

--- a/otter_welcome_buddy/formatters/englishclub_message.py
+++ b/otter_welcome_buddy/formatters/englishclub_message.py
@@ -1,0 +1,7 @@
+class Formatter:
+    """Dependency to inject messages"""
+
+    @staticmethod
+    def club_message() -> str:
+        """Message when a new user joins the discord"""
+        return "Hey yo, English club this week? 👀"

--- a/otter_welcome_buddy/formatters/englishclub_message.py
+++ b/otter_welcome_buddy/formatters/englishclub_message.py
@@ -16,7 +16,7 @@ class Formatter:
 
         to improve your language skills and connect with fellow language enthusiasts!
 
-        See you there! 🙌🇺🇸
+        See you there on the English Club channel! 🎭
         """
 
         return message

--- a/otter_welcome_buddy/formatters/englishclub_message.py
+++ b/otter_welcome_buddy/formatters/englishclub_message.py
@@ -11,10 +11,9 @@ class Formatter:
         """Message when an English session has been scheduled"""
         message = f"""
         📣 Join us for an exciting English Club session next Sunday at {hour} Pacific Time! 🕗🌟
-        📚 Let's dive into the world of English language and culture together.
-        It's a fantastic opportunity to practice your English skills and make new friends.
 
         🗓️ Mark your calendars and set a reminder to join us. Don't miss out on the chance
+
         to improve your language skills and connect with fellow language enthusiasts!
 
         See you there! 🙌🇺🇸

--- a/otter_welcome_buddy/startup/cogs.py
+++ b/otter_welcome_buddy/startup/cogs.py
@@ -2,6 +2,7 @@ from types import ModuleType  # pylint: disable=no-name-in-module
 
 from discord.ext.commands import Bot
 
+from otter_welcome_buddy.cogs import englishclub_reminder
 from otter_welcome_buddy.cogs import hiring_timelines  # , new_user_joins
 
 
@@ -17,6 +18,7 @@ async def register_cogs(bot: Bot) -> None:
     allowed_cogs: list[ModuleType] = [
         # new_user_joins,
         hiring_timelines,
+        englishclub_reminder,
     ]
 
     for cog in allowed_cogs:


### PR DESCRIPTION
### Description

This pull request introduces new functionality to automate weekly communication with the **english_non_teachers** channel on our Discord server. The aim is to inquire if there will be an English session. The process is as follows:

- Every Wednesday at 12:00 PM Pacific Time, a scheduled message will be sent to the **english_non_teachers** channel.

- If Gober or Uli respond to the bot with the command "!schedule_session [time in PT]", an announcement will be made in the **english-club** channel, notifying everyone about the upcoming session on Sunday at the scheduled time.

Implemented Commands (exclusive to Gober and Uli):

- `!english start`: Starts the automated communication process.
- `!english stop`: Stops the automated communication process.
- `schedule_session`: Schedules an English session.

In the **.env** document, the following constants are defined:

- `DISCORD_TOKEN`: Server token for authentication.
- `ROOT_CHANNEL_ID`: Channel ID for "english_non_teachers."
- `GENERAL_CHANNEL_ID`: Channel ID for "english-club."
- `USER_ONE_ID`: Account ID for Gober.
- `USER_TWO_ID`: Account ID for Uli.


Scheduled message for **english_non_teachers** channel:
![Alt Text](https://cdn.discordapp.com/attachments/1160427026839257133/1169477840924848199/Screenshot_2023-11-01_at_8.26.53_PM.png?ex=65558c1d&is=6543171d&hm=0eaceff39a4c35befa430eb9fec72d539e23e41d4cc594cc717a070f9c16c9c1&)


Announcement for **english-club** channel:
![Alt Text](https://cdn.discordapp.com/attachments/1160427026839257133/1169639382383337612/Screenshot_2023-11-02_at_7.09.04_AM.png?ex=6556228f&is=6543ad8f&hm=7e4a7b66452eaad222ab4c40ab9f6a1ec4ce5de76000dacf1122f767919b9f10&)

