### PR TITLE
english_club cog implementation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 default_language_version:
   # force all unspecified python hooks to run python3
-  python: python3
+  python: python3.10
 
 repos:
   - repo: https://github.com/asottile/pyupgrade

--- a/otter_welcome_buddy/cogs/english_club_reminder.py
+++ b/otter_welcome_buddy/cogs/english_club_reminder.py
@@ -1,0 +1,135 @@
+import os
+import re
+
+import discord
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from discord import TextChannel
+from discord.ext import commands
+from discord.ext.commands import Bot
+from discord.ext.commands import Context
+
+from otter_welcome_buddy.common.constants import CronExpressions
+from otter_welcome_buddy.common.constants import DiscordCommonRoles
+from otter_welcome_buddy.common.constants import OTTER_HEADER_IMAGE
+from otter_welcome_buddy.common.constants import OTTER_MODERATOR
+from otter_welcome_buddy.common.utils.dates import DateUtils
+from otter_welcome_buddy.common.utils.discord_ import get_channel_by_id
+from otter_welcome_buddy.common.utils.types.common import DiscordChannelType
+from otter_welcome_buddy.formatters import messages
+from otter_welcome_buddy.settings import ENGLISH_CHANNEL_ID
+from otter_welcome_buddy.settings import NON_ENGLISH_TEACHERS_CHANNEL_ID
+
+
+class English(commands.Cog):
+    """
+    English command events, where notifications about English sessions
+    Commands:
+        englishclub start:     Start cronjob for timeline messages
+        englishclub stop:      Stop cronjob for timeline messages
+    """
+
+    def __init__(self, bot: Bot, messages_dependency: type[messages.Formatter]):
+        self.bot: Bot = bot
+        self.messages_formatter: type[messages.Formatter] = messages_dependency
+        self.scheduler: AsyncIOScheduler = AsyncIOScheduler()
+        self.__configure_scheduler()
+
+    @commands.group(
+        brief="Commands related to English Club!",
+        invoke_without_command=True,
+        pass_context=True,
+    )
+    @commands.has_role(OTTER_MODERATOR)
+    async def englishclub(self, ctx: Context) -> None:
+        """
+        English Club will setup an English session
+        """
+        await ctx.send_help(ctx.command)
+
+    @englishclub.command(brief="Start the cronjob for the messages")  # type: ignore
+    @commands.has_role(OTTER_MODERATOR)
+    async def start(self, _: Context) -> None:
+        """Command to interact with the bot and start cron"""
+        self.__configure_scheduler()
+
+    @englishclub.command(brief="Stop the cronjob for the messages")  # type: ignore
+    @commands.has_role(OTTER_MODERATOR)
+    async def stop(self, _: Context) -> None:
+        """Command to interact with the bot and stop cron"""
+        self.scheduler.remove_job("job_id")
+
+    @commands.command(brief="Schedule an English session")
+    @commands.has_role(OTTER_MODERATOR)
+    async def schedule_session(self, ctx: Context, *hour: str) -> None:
+        """Schedule the English Club session"""
+
+        # Regex pattern explanation:
+        # ^: Asserts the start of the string.
+        # (1[0-2]|0?[1-9]): Matches an hour with the 12-hour format.
+        # : Matches the colon that separates the hour and minute.
+        # ([0-5][0-9]): Matches exactly 2 digits for the minutes, from "00" to "59".
+        #  ?: Matches zero or one space, allowing for space between the minutes and AM/PM.
+        # (AM|PM): Matches either "AM" or "PM" (case-sensitive).
+        # $: Asserts the end of the string.
+        time_format_regex = r"^(1[0-2]|0?[1-9]):([0-5][0-9]) ?(AM|PM)$"
+        hour_str: str = " ".join(hour)
+
+        if re.match(time_format_regex, hour_str):
+            channel_id: int = ENGLISH_CHANNEL_ID
+            channel: DiscordChannelType | None = get_channel_by_id(self.bot, channel_id)
+            everyone = DiscordCommonRoles.EVERYONE.value
+
+            embed = discord.Embed(
+                colour=discord.Colour.green(),
+                title="English Club Session",
+                description=everyone + self.messages_formatter.english_club_message(hour_str),
+            )
+
+            embed.set_image(url=OTTER_HEADER_IMAGE)
+
+            if isinstance(channel, TextChannel):
+                await channel.send(embed=embed)
+        else:
+            await ctx.send(
+                "Invalid, Use the following format: HH:MM AM or HH:MM PM, e.g., '10:00 PM'.",
+            )
+
+    def message_non_english_club(self) -> str:
+        """
+        Generate a message for the English Club reminder.
+        """
+
+        user_1 = f"<@{os.environ['USER_ONE_ID']}>"
+        user_2 = f"<@{os.environ['USER_TWO_ID']}>"
+        description = f"{self.messages_formatter.non_english_club_message()} {user_1} {user_2} 👀"
+
+        return description
+
+    def __configure_scheduler(self) -> None:
+        """Configure and start scheduler"""
+
+        self.scheduler.add_job(
+            self.send_message_on_english_non_teachers,
+            DateUtils.create_cron_trigger_from(
+                CronExpressions.WEDNESDAY_NOON_CRON.value,
+            ),
+            id="job_id",
+        )
+        self.scheduler.start()
+
+    async def send_message_on_english_non_teachers(self) -> None:
+        """
+        Sends message to english_non_teachers channel
+        """
+
+        channel_id: int = NON_ENGLISH_TEACHERS_CHANNEL_ID
+        channel: DiscordChannelType | None = get_channel_by_id(self.bot, channel_id)
+        if isinstance(channel, TextChannel):
+            await channel.send(self.message_non_english_club())
+        else:
+            raise TypeError("Not valid channel to send the message in")
+
+
+async def setup(bot: Bot) -> None:
+    """Set up"""
+    await bot.add_cog(English(bot, messages.Formatter))

--- a/otter_welcome_buddy/common/constants.py
+++ b/otter_welcome_buddy/common/constants.py
@@ -6,6 +6,14 @@ class CronExpressions(Enum):
     """Defined Cron Expressions"""
 
     DAY_ONE_OF_EACH_MONTH_CRON: str = "0 0 1 * *"
+    WEDNESDAY_NOON_CRON: str = "0 12 * * 2"
+
+
+class DiscordCommonRoles(Enum):
+    """Common roles present by default in Discord"""
+
+    EVERYONE: str = "@everyone"
+    HERE: str = "@here"
 
 
 COMMAND_PREFIX: str = "!"
@@ -27,3 +35,5 @@ OTTER_MODERATOR: str = "Collaborator"
 # Discord role that give access to the remaining channels and is
 # given when the user react to WELCOME_MESSAGES
 OTTER_ROLE: str = "Interviewee"
+# URL to the header image used for branding or visual identity in the Discord server
+OTTER_HEADER_IMAGE: str = "https://shorturl.at/blqMV"

--- a/otter_welcome_buddy/common/utils/dates.py
+++ b/otter_welcome_buddy/common/utils/dates.py
@@ -2,6 +2,8 @@ from datetime import datetime
 
 from apscheduler.triggers.cron import CronTrigger
 
+from otter_welcome_buddy.settings import TIME_ZONE
+
 
 class DateUtils:
     """Utility class for datetime python library"""
@@ -14,4 +16,4 @@ class DateUtils:
     @staticmethod
     def create_cron_trigger_from(crontab: str) -> CronTrigger:
         """Returns cron trigger from crontab"""
-        return CronTrigger.from_crontab(crontab)
+        return CronTrigger.from_crontab(crontab, TIME_ZONE)

--- a/otter_welcome_buddy/common/utils/discord_.py
+++ b/otter_welcome_buddy/common/utils/discord_.py
@@ -1,0 +1,10 @@
+from discord.ext.commands import Bot
+
+from otter_welcome_buddy.common.utils.types.common import DiscordChannelType
+
+
+def get_channel_by_id(bot: Bot, channel_id: int) -> DiscordChannelType | None:
+    """
+    Function to get the a channel by ID
+    """
+    return bot.get_channel(channel_id) if channel_id else None

--- a/otter_welcome_buddy/formatters/messages.py
+++ b/otter_welcome_buddy/formatters/messages.py
@@ -5,3 +5,23 @@ class Formatter:
     def welcome_message() -> str:
         """Message when a new user joins the discord"""
         return "Welcome to Proyecto Nutria"
+
+    @staticmethod
+    def non_english_club_message() -> str:
+        """Message ask English session"""
+        return "Hey yo, English club this week? "
+
+    @staticmethod
+    def english_club_message(hour: str) -> str:
+        """Message when an English session has been scheduled"""
+        message = f"""
+        📣 Join us for an exciting English Club session next Sunday at {hour} Pacific Time! 🕗🌟
+
+        🗓️ Mark your calendars and set a reminder to join us. Don't miss out on the chance
+
+        to improve your language skills and connect with fellow language enthusiasts!
+
+        See you there on the English Club channel! 🎭
+        """
+
+        return message

--- a/otter_welcome_buddy/settings.py
+++ b/otter_welcome_buddy/settings.py
@@ -1,3 +1,4 @@
+import os
 from os import getenv
 
 from dotenv import load_dotenv
@@ -6,3 +7,6 @@ load_dotenv()
 
 
 WELCOME_MESSAGES = getenv("WELCOME_MESSAGES", "").split(",")
+TIME_ZONE: str = "America/Mexico_City"
+ENGLISH_CHANNEL_ID: int = int(os.environ["GENERAL_CHANNEL_ID"])
+NON_ENGLISH_TEACHERS_CHANNEL_ID: int = int(os.environ["ROOT_CHANNEL_ID"])

--- a/otter_welcome_buddy/startup/cogs.py
+++ b/otter_welcome_buddy/startup/cogs.py
@@ -2,6 +2,7 @@ from types import ModuleType  # pylint: disable=no-name-in-module
 
 from discord.ext.commands import Bot
 
+from otter_welcome_buddy.cogs import english_club_reminder
 from otter_welcome_buddy.cogs import events
 from otter_welcome_buddy.cogs import hiring_timelines
 from otter_welcome_buddy.cogs import new_user_joins
@@ -20,6 +21,7 @@ async def register_cogs(bot: Bot) -> None:
         events,
         new_user_joins,
         hiring_timelines,
+        english_club_reminder,
     ]
 
     for cog in allowed_cogs:


### PR DESCRIPTION
### Description

This pull request introduces new functionality to automate weekly communication with the **english_non_teachers** channel on our Discord server. The aim is to inquire if there will be an English session. The process is as follows:

- Every Wednesday at 12:00 PM Pacific Time, a scheduled message will be sent to the **english_non_teachers** channel.

- If Gober or Uli respond to the bot with the command "!schedule_session [time in PT]", an announcement will be made in the **english-club** channel, notifying everyone about the upcoming session on Sunday at the scheduled time.

Implemented Commands (exclusive to Collaborators):

- `!english start`: Starts the automated communication process.
- `!english stop`: Stops the automated communication process.
- `!schedule_session`: Schedules an English session.

In the **.env** document, the following constants are defined:

- `DISCORD_TOKEN`: Server token for authentication.
- `ROOT_CHANNEL_ID`: Channel ID for "english_non_teachers."
- `GENERAL_CHANNEL_ID`: Channel ID for "english-club."
- `USER_ONE_ID`: Account ID for Gober.
- `USER_TWO_ID`: Account ID for Uli.


Scheduled message for **english_non_teachers** channel:
![Alt Text](https://cdn.discordapp.com/attachments/1160427026839257133/1169477840924848199/Screenshot_2023-11-01_at_8.26.53_PM.png?ex=65558c1d&is=6543171d&hm=0eaceff39a4c35befa430eb9fec72d539e23e41d4cc594cc717a070f9c16c9c1&)


Announcement for **english-club** channel:
![Alt Text](https://cdn.discordapp.com/attachments/1160427026839257133/1169639382383337612/Screenshot_2023-11-02_at_7.09.04_AM.png?ex=6556228f&is=6543ad8f&hm=7e4a7b66452eaad222ab4c40ab9f6a1ec4ce5de76000dacf1122f767919b9f10&)

