### PR TITLE
Create send message util

### DIFF
--- a/otter_welcome_buddy/cogs/interview_match.py
+++ b/otter_welcome_buddy/cogs/interview_match.py
@@ -2,7 +2,6 @@ import asyncio
 import datetime
 import logging
 import random
-from sqlite3 import ProgrammingError
 
 import discord
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
@@ -14,6 +13,7 @@ from discord.ext.commands import Context
 from otter_welcome_buddy.common.constants import OTTER_ADMIN
 from otter_welcome_buddy.common.constants import OTTER_MODERATOR
 from otter_welcome_buddy.common.constants import OTTER_ROLE
+from otter_welcome_buddy.common.utils.discord_ import send_plain_message
 from otter_welcome_buddy.common.utils.image import create_match_image
 from otter_welcome_buddy.common.utils.types.common import DiscordChannelType
 from otter_welcome_buddy.database.handlers.db_interview_match_handler import DbInterviewMatchHandler
@@ -398,15 +398,12 @@ class InterviewMatch(commands.Cog):
             DbInterviewMatchHandler.insert_interview_match(
                 interview_match_model=interview_match_model,
             )
-            await ctx.send(
+            await send_plain_message(
+                ctx,
                 f"**Interview Match** activity scheduled! See you there {emoji_selected}.",
             )
-        except ProgrammingError:
+        except Exception:
             logger.exception("Error while inserting into database")
-        except discord.Forbidden:
-            logger.exception("Not enough permissions to send the starting message")
-        except discord.HTTPException:
-            logger.exception("Sending the starting message failed")
 
     @interview_match.command(brief="Stop interview match activity")  # type: ignore
     @commands.has_any_role(OTTER_ADMIN, OTTER_MODERATOR)
@@ -427,13 +424,9 @@ class InterviewMatch(commands.Cog):
                 msg = "**Interview Match** activity stopped!"
             else:
                 msg = "No activity was running! 😱"
-            await ctx.send(msg)
-        except ProgrammingError:
-            logger.exception("Error while deleting from database")
-        except discord.Forbidden:
-            logger.exception("Not enough permissions to send the stopping message")
-        except discord.HTTPException:
-            logger.exception("Sending the stopping message failed")
+            await send_plain_message(ctx, msg)
+        except Exception:
+            logger.exception("Error while inserting into database")
 
     @interview_match.group(  # type: ignore
         brief="Commands related to trigger manually the Interview Match activity!",

--- a/otter_welcome_buddy/common/utils/discord_.py
+++ b/otter_welcome_buddy/common/utils/discord_.py
@@ -1,0 +1,17 @@
+import logging
+
+import discord
+from discord.ext.commands import Context
+
+
+logger = logging.getLogger(__name__)
+
+
+async def send_plain_message(ctx: Context, message: str) -> None:
+    """Send a message as embed, this allows to use more markdown features"""
+    try:
+        await ctx.send(embed=discord.Embed(description=message, color=discord.Color.teal()))
+    except discord.Forbidden:
+        logger.exception("Not enough permissions to send the message")
+    except discord.HTTPException:
+        logger.exception("Sending the message failed")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,11 +9,18 @@ from discord import Guild
 from discord import Member
 from discord import Role
 from discord.ext.commands import Bot
+from discord.ext.commands import Context
 from mongoengine import connect as mongo_connect
 from mongoengine import disconnect as mongo_disconnect
 from mongomock import MongoClient
 
 from otter_welcome_buddy.database.models.external.guild_model import GuildModel
+
+
+@pytest.fixture
+def mock_ctx() -> Context:
+    mocked_ctx = AsyncMock()
+    return mocked_ctx
 
 
 @pytest.fixture

--- a/tests/utils/test_discord_.py
+++ b/tests/utils/test_discord_.py
@@ -1,0 +1,22 @@
+import discord
+import pytest
+from discord.ext.commands import Context
+from pytest_mock import MockFixture
+
+from otter_welcome_buddy.common.utils import discord_
+
+
+@pytest.mark.asyncio
+async def test_send_plain_message(mocker: MockFixture, mock_ctx: Context) -> None:
+    # Arrange
+    test_msg: str = "Test message"
+
+    mock_ctx_send = mocker.patch.object(mock_ctx, "send")
+
+    # Act
+    await discord_.send_plain_message(mock_ctx, test_msg)
+
+    # Assert
+    mock_ctx_send.assert_called_once_with(
+        embed=discord.Embed(description=test_msg, color=discord.Color.teal()),
+    )


### PR DESCRIPTION
# Description

### Context
Currently the hiring timelines announcements depends on an ENV variable to send the message, that approach is not extensible to other guilds and other channels, and is not maintainable in the time. Because of that we're migrating the configuration to the database.

### This diff
* Create a send message util to use the embed and catch any errors to avoid repetitive code

### Incoming diffs
* Add announcement config model 
* Update the hiring timeline command to use the new configuration from the database

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

Added unit test

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
