### PR TITLE
Add announcements config model

### DIFF
--- a/otter_welcome_buddy/database/handlers/db_announcements_config_handler.py
+++ b/otter_welcome_buddy/database/handlers/db_announcements_config_handler.py
@@ -1,0 +1,49 @@
+from mongoengine import DoesNotExist
+
+from otter_welcome_buddy.database.models.external.announcements_config_model import (
+    AnnouncementsConfigModel,
+)
+
+
+class DbAnnouncementsConfigHandler:
+    """Class to interact with the table announcements_config via static methods"""
+
+    @staticmethod
+    def get_announcements_config(
+        guild_id: int,
+    ) -> AnnouncementsConfigModel | None:
+        """Static method to get an announcement config by its guild_id"""
+        try:
+            announcements_config_model: AnnouncementsConfigModel = AnnouncementsConfigModel.objects(
+                guild=guild_id,
+            ).get()
+            return announcements_config_model
+        except DoesNotExist:
+            return None
+
+    @staticmethod
+    def get_all_announcements_configs() -> list[AnnouncementsConfigModel]:
+        """Static method to get all the interview matches for a day"""
+        announcements_config_models: list[AnnouncementsConfigModel] = list(
+            AnnouncementsConfigModel.objects(),
+        )
+        return announcements_config_models
+
+    @staticmethod
+    def insert_announcements_config(
+        announcements_config_model: AnnouncementsConfigModel,
+    ) -> AnnouncementsConfigModel:
+        """Static method to insert (or update) an announcement config record"""
+        announcements_config_model = announcements_config_model.save()
+        return announcements_config_model
+
+    @staticmethod
+    def delete_announcements_config(guild_id: int) -> None:
+        """Static method to delete an announcement config record by a guild_id"""
+        announcements_config_model: AnnouncementsConfigModel | None = (
+            AnnouncementsConfigModel.objects(
+                guild=guild_id,
+            ).first()
+        )
+        if announcements_config_model:
+            announcements_config_model.delete()

--- a/otter_welcome_buddy/database/models/external/announcements_config_model.py
+++ b/otter_welcome_buddy/database/models/external/announcements_config_model.py
@@ -1,0 +1,17 @@
+from mongoengine import CASCADE
+from mongoengine import Document
+from mongoengine import IntField
+from mongoengine import ReferenceField
+
+
+class AnnouncementsConfigModel(Document):
+    """
+    A model that indicates where to send the announcements.
+
+    Attributes:
+        guild (GuildModel):     Reference to the guild that want to receive the announcements
+        channel_id (int):       Channel identifier where to send the announcement
+    """
+
+    guild = ReferenceField("GuildModel", reverse_delete_rule=CASCADE, required=True)
+    channel_id = IntField(required=True)

--- a/otter_welcome_buddy/database/models/external/announcements_config_model.py
+++ b/otter_welcome_buddy/database/models/external/announcements_config_model.py
@@ -13,5 +13,5 @@ class AnnouncementsConfigModel(Document):
         channel_id (int):       Channel identifier where to send the announcement
     """
 
-    guild = ReferenceField("GuildModel", reverse_delete_rule=CASCADE, required=True)
+    guild = ReferenceField("GuildModel", reverse_delete_rule=CASCADE, primary_key=True)
     channel_id = IntField(required=True)

--- a/otter_welcome_buddy/database/models/external/interview_match_model.py
+++ b/otter_welcome_buddy/database/models/external/interview_match_model.py
@@ -18,7 +18,7 @@ class InterviewMatchModel(Document):
         message_id (int):       Identifier of the message that will be processed for the activity
     """
 
-    guild = ReferenceField("GuildModel", reverse_delete_rule=CASCADE, required=True)
+    guild = ReferenceField("GuildModel", reverse_delete_rule=CASCADE, primary_key=True)
     author_id = IntField(required=True)
     channel_id = IntField(required=True)
     day_of_the_week = IntField(required=True)

--- a/tests/database/handlers/test_db_announcements_config_handler.py
+++ b/tests/database/handlers/test_db_announcements_config_handler.py
@@ -1,0 +1,121 @@
+import pytest
+from mongoengine import DoesNotExist
+from mongoengine import ValidationError
+from mongomock import MongoClient
+
+from otter_welcome_buddy.database.handlers.db_announcements_config_handler import (
+    DbAnnouncementsConfigHandler,
+)
+from otter_welcome_buddy.database.models.external.announcements_config_model import (
+    AnnouncementsConfigModel,
+)
+from otter_welcome_buddy.database.models.external.guild_model import GuildModel
+
+
+def test_get_announcements_config_succeed(
+    temporary_mongo_connection: MongoClient,
+    mock_guild_model: GuildModel,
+) -> None:
+    # Arrange
+    mocked_guild_id: int = mock_guild_model.guild_id
+    mocked_announcements_config_model: AnnouncementsConfigModel = AnnouncementsConfigModel(
+        guild=mocked_guild_id,
+        channel_id=123,
+    )
+    mocked_announcements_config_model.save()
+
+    # Act
+    result = DbAnnouncementsConfigHandler.get_announcements_config(guild_id=mocked_guild_id)
+
+    # Assert
+    assert result is not None
+    assert result.guild.id == mocked_guild_id
+
+
+def test_get_announcements_config_not_found(temporary_mongo_connection: MongoClient) -> None:
+    # Act
+    result = DbAnnouncementsConfigHandler.get_announcements_config(guild_id=123)
+
+    # Assert
+    assert result is None
+
+
+def test_get_all_announcements_configs(
+    temporary_mongo_connection: MongoClient,
+    mock_guild_model: GuildModel,
+) -> None:
+    # Arrange
+    mocked_guild_id: int = mock_guild_model.guild_id
+    mocked_announcements_config_model: AnnouncementsConfigModel = AnnouncementsConfigModel(
+        guild=mocked_guild_id,
+        channel_id=123,
+    )
+    mocked_announcements_config_model.save()
+
+    # Act
+    results = DbAnnouncementsConfigHandler.get_all_announcements_configs()
+
+    # Assert
+    assert len(results) == 1
+    assert results[0].guild.id == mocked_guild_id
+
+
+def test_insert_announcements_config_succeed(
+    temporary_mongo_connection: MongoClient,
+    mock_guild_model: GuildModel,
+) -> None:
+    # Arrange
+    mocked_guild_id: int = mock_guild_model.guild_id
+    mocked_announcements_config_model: AnnouncementsConfigModel = AnnouncementsConfigModel(
+        guild=mocked_guild_id,
+        channel_id=123,
+    )
+
+    # Act
+    result = DbAnnouncementsConfigHandler.insert_announcements_config(
+        announcements_config_model=mocked_announcements_config_model,
+    )
+
+    # Assert
+    assert result is not None
+    assert result.guild.guild_id == mocked_guild_id
+
+
+def test_insert_announcements_config_failed(temporary_mongo_connection: MongoClient) -> None:
+    # Arrange
+    mocked_announcements_config_model: AnnouncementsConfigModel = AnnouncementsConfigModel()
+
+    # Act / Assert
+    with pytest.raises(ValidationError):
+        DbAnnouncementsConfigHandler.insert_announcements_config(
+            announcements_config_model=mocked_announcements_config_model,
+        )
+
+
+def test_delete_announcements_config_valid_id(
+    temporary_mongo_connection: MongoClient,
+    mock_guild_model: GuildModel,
+) -> None:
+    # Arrange
+    mocked_guild_id: int = mock_guild_model.guild_id
+    mocked_announcements_config_model: AnnouncementsConfigModel = AnnouncementsConfigModel(
+        guild=mocked_guild_id,
+        channel_id=123,
+    )
+    mocked_announcements_config_model.save()
+
+    # Act
+    DbAnnouncementsConfigHandler.delete_announcements_config(guild_id=mocked_guild_id)
+
+    # Assert
+    with pytest.raises(DoesNotExist):
+        AnnouncementsConfigModel.objects(guild=mocked_guild_id).get()
+
+
+def test_delete_announcements_config_invalid_id(temporary_mongo_connection: MongoClient) -> None:
+    # Act
+    DbAnnouncementsConfigHandler.delete_announcements_config(guild_id=123)
+
+    # Assert
+    with pytest.raises(DoesNotExist):
+        AnnouncementsConfigModel.objects(guild=123).get()


### PR DESCRIPTION
# Description

### Context
Currently the hiring timelines announcements depends on an ENV variable to send the message, that approach is not extensible to other guilds and other channels, and is not maintainable in the time. Because of that we're migrating the configuration to the database.

### This diff
* Add announcement config model 

### Incoming diffs
* Update the hiring timeline command to use the new configuration from the database

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

Added unit tests

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
