### PR TITLE
Add role config model

### DIFF
--- a/otter_welcome_buddy/database/handlers/db_role_config_handler.py
+++ b/otter_welcome_buddy/database/handlers/db_role_config_handler.py
@@ -1,0 +1,61 @@
+from mongoengine import DoesNotExist
+
+from otter_welcome_buddy.database.models.external.role_config_model import BaseRoleConfigModel
+
+
+class DbRoleConfigHandler:
+    """Class to interact with the table role_config via static methods"""
+
+    @staticmethod
+    def get_base_role_config(
+        guild_id: int,
+    ) -> BaseRoleConfigModel | None:
+        """Static method to get the base role config by its guild_id"""
+        try:
+            base_role_config_model: BaseRoleConfigModel = BaseRoleConfigModel.objects(
+                guild=guild_id,
+            ).get()
+            return base_role_config_model
+        except DoesNotExist:
+            return None
+
+    @staticmethod
+    def get_all_base_role_configs() -> list[BaseRoleConfigModel]:
+        """Static method to get all the base role configs in the database"""
+        base_role_config_models: list[BaseRoleConfigModel] = list(BaseRoleConfigModel.objects())
+        return base_role_config_models
+
+    @staticmethod
+    def insert_base_role_config(base_role_config_model: BaseRoleConfigModel) -> BaseRoleConfigModel:
+        """Static method to insert (or update) a base role config record"""
+        base_role_config_model = base_role_config_model.save()
+        return base_role_config_model
+
+    @staticmethod
+    def delete_base_role_config(guild_id: int) -> None:
+        """Static method to delete a base role config record by a guild_id"""
+        base_role_config_model: BaseRoleConfigModel | None = BaseRoleConfigModel.objects(
+            guild=guild_id,
+        ).first()
+        if base_role_config_model:
+            base_role_config_model.delete()
+
+    @staticmethod
+    def delete_message_from_base_role_config(
+        guild_id: int,
+        input_message_id: int,
+    ) -> BaseRoleConfigModel | None:
+        """Static method to delete a base role config record by a guild_id"""
+        base_role_config_model: BaseRoleConfigModel | None = BaseRoleConfigModel.objects(
+            guild=guild_id,
+        ).first()
+
+        if not base_role_config_model:
+            return None
+
+        base_role_config_model.message_ids = [
+            message_id
+            for message_id in base_role_config_model.message_ids
+            if message_id != input_message_id
+        ]
+        return DbRoleConfigHandler.insert_base_role_config(base_role_config_model)

--- a/otter_welcome_buddy/database/models/external/role_config_model.py
+++ b/otter_welcome_buddy/database/models/external/role_config_model.py
@@ -1,0 +1,20 @@
+from mongoengine import CASCADE
+from mongoengine import Document
+from mongoengine import IntField
+from mongoengine import ListField
+from mongoengine import ReferenceField
+
+from otter_welcome_buddy.database.models.external.guild_model import GuildModel
+
+
+class BaseRoleConfigModel(Document):
+    """
+    A model that represents the configuration to get the base role for the server in the database.
+
+    Attributes:
+        guild (GuildModel):     Reference to the guild that the activity belongs to
+        message_ids (int):      List of message identifiers that the user needs to react to
+    """
+
+    guild = ReferenceField(GuildModel, reverse_delete_rule=CASCADE, primary_key=True)
+    message_ids = ListField(IntField(required=True))

--- a/tests/database/handlers/test_db_role_config_handler.py
+++ b/tests/database/handlers/test_db_role_config_handler.py
@@ -1,0 +1,161 @@
+import pytest
+from mongoengine import DoesNotExist
+from mongoengine import ValidationError
+from mongomock import MongoClient
+
+from otter_welcome_buddy.database.handlers.db_role_config_handler import DbRoleConfigHandler
+from otter_welcome_buddy.database.models.external.guild_model import GuildModel
+from otter_welcome_buddy.database.models.external.role_config_model import BaseRoleConfigModel
+
+
+@pytest.fixture
+def mock_base_role_config_model(mock_guild_model: GuildModel) -> BaseRoleConfigModel:
+    mocked_base_role_config_model = BaseRoleConfigModel(
+        guild=mock_guild_model,
+        message_ids=[123],
+    )
+    return mocked_base_role_config_model
+
+
+def test_get_base_role_config_succeed(
+    temporary_mongo_connection: MongoClient,
+    mock_base_role_config_model: BaseRoleConfigModel,
+) -> None:
+    # Arrange
+    mocked_guild_id: int = mock_base_role_config_model.guild.id
+    mock_base_role_config_model.save()
+
+    # Act
+    result = DbRoleConfigHandler.get_base_role_config(guild_id=mocked_guild_id)
+
+    # Assert
+    assert result is not None
+    assert result.guild.id == mocked_guild_id
+    assert len(result.message_ids) == 1
+
+
+def test_get_base_role_config_not_found(temporary_mongo_connection: MongoClient) -> None:
+    # Act
+    result = DbRoleConfigHandler.get_base_role_config(guild_id=123)
+
+    # Assert
+    assert result is None
+
+
+def test_get_all_base_role_configs_succeed(
+    temporary_mongo_connection: MongoClient,
+    mock_base_role_config_model: BaseRoleConfigModel,
+) -> None:
+    # Arrange
+    mock_base_role_config_model.save()
+
+    # Act
+    results = DbRoleConfigHandler.get_all_base_role_configs()
+
+    # Assert
+    assert len(results) == 1
+
+
+def test_get_all_base_role_configs_empty(
+    temporary_mongo_connection: MongoClient,
+) -> None:
+    # Act
+    results = DbRoleConfigHandler.get_all_base_role_configs()
+
+    # Assert
+    assert len(results) == 0
+
+
+def test_insert_base_role_config_succeed(
+    temporary_mongo_connection: MongoClient,
+    mock_base_role_config_model: BaseRoleConfigModel,
+) -> None:
+    # Arrange
+    mocked_guild_id: int = mock_base_role_config_model.guild.id
+
+    # Act
+    result = DbRoleConfigHandler.insert_base_role_config(
+        base_role_config_model=mock_base_role_config_model,
+    )
+
+    # Assert
+    assert result is not None
+    assert result.guild.guild_id == mocked_guild_id
+
+
+def test_insert_base_role_config_failed(temporary_mongo_connection: MongoClient) -> None:
+    # Arrange
+    mocked_base_role_config_model: BaseRoleConfigModel = BaseRoleConfigModel()
+
+    # Act / Assert
+    with pytest.raises(ValidationError):
+        DbRoleConfigHandler.insert_base_role_config(
+            base_role_config_model=mocked_base_role_config_model,
+        )
+
+
+def test_delete_base_role_config_valid_id(
+    temporary_mongo_connection: MongoClient,
+    mock_base_role_config_model: BaseRoleConfigModel,
+) -> None:
+    # Arrange
+    mocked_guild_id: int = mock_base_role_config_model.guild.id
+    mock_base_role_config_model.save()
+
+    # Act
+    DbRoleConfigHandler.delete_base_role_config(guild_id=mocked_guild_id)
+
+    # Assert
+    with pytest.raises(DoesNotExist):
+        BaseRoleConfigModel.objects(guild=mocked_guild_id).get()
+
+
+def test_delete_base_role_config_invalid_id(temporary_mongo_connection: MongoClient) -> None:
+    # Act
+    DbRoleConfigHandler.delete_base_role_config(guild_id=123)
+
+    # Assert
+    with pytest.raises(DoesNotExist):
+        BaseRoleConfigModel.objects(guild=123).get()
+
+
+def test_delete_message_from_base_role_config_valid_id(
+    temporary_mongo_connection: MongoClient,
+    mock_base_role_config_model: BaseRoleConfigModel,
+) -> None:
+    # Arrange
+    mocked_guild_id: int = mock_base_role_config_model.guild.id
+    mock_base_role_config_model.message_ids = [123, 456, 789]
+    mock_base_role_config_model.save()
+
+    # Act
+    result = DbRoleConfigHandler.delete_message_from_base_role_config(
+        guild_id=mocked_guild_id,
+        input_message_id=123,
+    )
+
+    # Assert
+    assert result is not None
+    assert result.guild.id == mocked_guild_id
+    assert len(result.message_ids) == 2
+
+
+def test_delete_message_from_base_role_config_invalid_id(
+    temporary_mongo_connection: MongoClient,
+    mock_base_role_config_model: BaseRoleConfigModel,
+) -> None:
+    # Arrange
+    mocked_guild_id: int = mock_base_role_config_model.guild.id
+    mock_base_role_config_model.message_ids = [123, 456, 789]
+    mock_base_role_config_model.save()
+
+    # Act
+    result = DbRoleConfigHandler.delete_message_from_base_role_config(
+        guild_id=mocked_guild_id,
+        input_message_id=0,
+    )
+
+    # Assert
+    assert result is not None
+    assert result.guild.id == mocked_guild_id
+    assert len(result.message_ids) == 3


### PR DESCRIPTION
# Description

### Context
Currently giving the base role (`OTTER_ROLE`) depends on an ENV variable when a user reacts to the message, that approach is not extensible to other guilds and other channels, and is not maintainable in the time. Because of that we're migrating the configuration to the database.

### This diff
* Add base role config model 

### Incoming diffs
* Add welcome messages role command
* Update `on_raw_reaction_add` event to use the database data

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

Added unit tests

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
