### PR TITLE
Add welcome messages role command

### DIFF
--- a/otter_welcome_buddy/cogs/command_template.py
+++ b/otter_welcome_buddy/cogs/command_template.py
@@ -15,7 +15,7 @@ class CommandTemplate(commands.Cog):
     def __init__(self, bot: Bot):
         self.bot: Bot = bot
 
-    @commands.group()
+    @commands.group(invoke_without_command=True)
     async def my_group(self, ctx: Context) -> None:
         """
         CommandTemplate will send the help when no final command is invoked
@@ -26,7 +26,7 @@ class CommandTemplate(commands.Cog):
     async def my_command(self, _: Context) -> None:
         """!my_group my_command"""
 
-    @my_group.group()  # type: ignore
+    @my_group.group(invoke_without_command=True)  # type: ignore
     async def my_group_2(self, ctx: Context) -> None:
         """
         CommandTemplate will send the help when no final command is invoked

--- a/otter_welcome_buddy/cogs/roles.py
+++ b/otter_welcome_buddy/cogs/roles.py
@@ -1,0 +1,125 @@
+import logging
+
+from discord.ext import commands
+from discord.ext.commands import Bot
+from discord.ext.commands import Context
+
+from otter_welcome_buddy.common.constants import OTTER_ADMIN
+from otter_welcome_buddy.common.constants import OTTER_MODERATOR
+from otter_welcome_buddy.common.constants import OTTER_ROLE
+from otter_welcome_buddy.common.utils.discord_ import send_plain_message
+from otter_welcome_buddy.database.handlers.db_role_config_handler import DbRoleConfigHandler
+from otter_welcome_buddy.database.models.external.role_config_model import BaseRoleConfigModel
+
+
+logger = logging.getLogger(__name__)
+
+
+class Roles(commands.Cog):
+    """
+    Refer to this template when adding a new command for the bot,
+    once done, call it on the cogs.py file
+    Commands:
+        roles welcome add
+        roles welcome remove
+    """
+
+    def __init__(self, bot: Bot):
+        self.bot: Bot = bot
+
+    @commands.group(
+        brief="Commands related to give roles to the users",
+        invoke_without_command=True,
+    )
+    async def roles(self, ctx: Context) -> None:
+        """
+        Roles will send the help when no final command is invoked
+        """
+        await ctx.send_help(ctx.command)
+
+    @roles.group(  # type: ignore
+        brief="Commands related to give the otter role to the users "
+        "when reacting to the welcome messages",
+        invoke_without_command=True,
+    )
+    @commands.has_any_role(OTTER_ADMIN, OTTER_MODERATOR)
+    async def welcome(self, ctx: Context) -> None:
+        """
+        Roles will send the help when no final command is invoked
+        """
+        await ctx.send_help(ctx.command)
+
+    @welcome.command(usage="<message_ids>")  # type: ignore
+    @commands.has_any_role(OTTER_ADMIN, OTTER_MODERATOR)
+    async def add(self, ctx: Context, input_message_ids: commands.Greedy[int]) -> None:
+        """
+        Add one or more message ids separated by whitespaces
+        to the database to be used as welcome messages
+        """
+        # Remove duplicates
+        message_ids: list[int] = list(set(input_message_ids))
+        if ctx.guild is None:
+            logger.warning("No guild on context to save the messages")
+            return
+
+        try:
+            base_role_config_model = DbRoleConfigHandler.get_base_role_config(
+                guild_id=ctx.guild.id,
+            )
+            if base_role_config_model is not None:
+                message_ids.extend(base_role_config_model.message_ids)
+                base_role_config_model.message_ids = list(set(message_ids))
+            else:
+                base_role_config_model = BaseRoleConfigModel(
+                    guild=ctx.guild.id,
+                    message_ids=message_ids,
+                )
+
+            base_role_config_model = DbRoleConfigHandler.insert_base_role_config(
+                base_role_config_model=base_role_config_model,
+            )
+
+            await send_plain_message(
+                ctx,
+                f"**Welcome message** saved! React to it to give the role **{OTTER_ROLE}**",
+            )
+        except Exception:
+            logger.exception("Error while inserting into database")
+
+    @welcome.command()  # type: ignore
+    @commands.has_any_role(OTTER_ADMIN, OTTER_MODERATOR)
+    async def remove(self, ctx: Context, message_id: int | None = None) -> None:
+        """
+        Remove messages from the database to be used as welcome messages.
+        If no message_id is provided, all messages will be removed
+        """
+        if ctx.guild is None:
+            logger.warning("No guild on context to save the messages")
+            return
+
+        try:
+            base_role_config_model = DbRoleConfigHandler.get_base_role_config(
+                guild_id=ctx.guild.id,
+            )
+            if base_role_config_model is not None:
+                if message_id is None:
+                    DbRoleConfigHandler.delete_base_role_config(guild_id=ctx.guild.id)
+                    msg = "**Welcome messages** removed!"
+                else:
+                    base_role_config_model = (
+                        DbRoleConfigHandler.delete_message_from_base_role_config(
+                            guild_id=ctx.guild.id,
+                            input_message_id=message_id,
+                        )
+                    )
+                    msg = "**Welcome message** deleted!"
+            else:
+                msg = "No welcome messages set! 😱"
+            await send_plain_message(ctx, msg)
+        except Exception:
+            logger.exception("Error while inserting into database")
+
+
+async def setup(bot: Bot) -> None:
+    """Required setup method"""
+    await bot.add_cog(Roles(bot))

--- a/otter_welcome_buddy/startup/cogs.py
+++ b/otter_welcome_buddy/startup/cogs.py
@@ -7,6 +7,7 @@ from otter_welcome_buddy.cogs import events
 from otter_welcome_buddy.cogs import hiring_timelines
 from otter_welcome_buddy.cogs import interview_match
 from otter_welcome_buddy.cogs import new_user_joins
+from otter_welcome_buddy.cogs import roles
 
 
 logger = logging.getLogger(__name__)
@@ -26,6 +27,7 @@ async def register_cogs(bot: Bot) -> None:
         new_user_joins,
         hiring_timelines,
         interview_match,
+        roles,
     ]
 
     for cog in allowed_cogs:

--- a/tests/startup/test_cogs.py
+++ b/tests/startup/test_cogs.py
@@ -26,4 +26,4 @@ async def test_loadExtensions_registerCogs() -> None:
     await cogs.register_cogs(mock_bot)
 
     # Assert
-    assert mock_bot.load_extension.call_count == 4
+    assert mock_bot.load_extension.call_count == 5


### PR DESCRIPTION
# Description

### Context
Currently giving the base role (`OTTER_ROLE`) depends on an ENV variable when a user reacts to the message, that approach is not extensible to other guilds and other channels, and is not maintainable in the time. Because of that we're migrating the configuration to the database.

### This diff
* Add welcome messages role command

### Incoming diffs
* Update `on_raw_reaction_add` event to use the database data

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

Manually tested on a test server

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
