### PR TITLE
Update on_reaction_add to use database data

### DIFF
--- a/.github/workflows/push_to_dev.yml
+++ b/.github/workflows/push_to_dev.yml
@@ -37,7 +37,7 @@ jobs:
           registry-username: ${{ secrets.REGISTRY_USERNAME }}
           registry-password: ${{ secrets.REGISTRY_PASSWORD }}
           name: ${{ secrets.REGISTRY_NAME }}
-          secure-environment-variables: DISCORD_TOKEN=${{ secrets.DISCORD_TOKEN }} ANNOUNCEMENT_CHANNEL_ID=${{ secrets.ANNOUNCEMENT_CHANNEL_ID }} MONGO_URI=${{ secrets.MONGO_URI }} WELCOME_MESSAGES=${{ secrets.WELCOME_MESSAGES}}
+          secure-environment-variables: DISCORD_TOKEN=${{ secrets.DISCORD_TOKEN }} ANNOUNCEMENT_CHANNEL_ID=${{ secrets.ANNOUNCEMENT_CHANNEL_ID }} MONGO_URI=${{ secrets.MONGO_URI }}
           location: ${{ secrets.RESOURCE_GROUP_LOCATION }}
           log-analytics-workspace: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
           log-analytics-workspace-key: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}

--- a/.github/workflows/push_to_prod.yml
+++ b/.github/workflows/push_to_prod.yml
@@ -37,7 +37,7 @@ jobs:
           registry-username: ${{ secrets.REGISTRY_USERNAME }}
           registry-password: ${{ secrets.REGISTRY_PASSWORD }}
           name: ${{ secrets.REGISTRY_NAME }}
-          secure-environment-variables: DISCORD_TOKEN=${{ secrets.DISCORD_TOKEN }} ANNOUNCEMENT_CHANNEL_ID=${{ secrets.ANNOUNCEMENT_CHANNEL_ID }} MONGO_URI=${{ secrets.MONGO_URI }} WELCOME_MESSAGES=${{ secrets.WELCOME_MESSAGES}}
+          secure-environment-variables: DISCORD_TOKEN=${{ secrets.DISCORD_TOKEN }} ANNOUNCEMENT_CHANNEL_ID=${{ secrets.ANNOUNCEMENT_CHANNEL_ID }} MONGO_URI=${{ secrets.MONGO_URI }}
           location: ${{ secrets.RESOURCE_GROUP_LOCATION }}
           log-analytics-workspace: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
           log-analytics-workspace-key: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}

--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ You need to install all the prerequisites before following with the instalation 
 You need the following environmental variables either in a `.env` file under the root directory of this repository or directly added at your system (or your Docker instance):
 
 * `DISCORD_TOKEN`: the Discord Bot Token retrieved from the [developer page](https://discord.com/developers/applications).
-* `WELCOME_MESSAGES`: [`message ids`](https://discordpy.readthedocs.io/en/stable/api.html?highlight=message%20id#discord.Message.id) separated by `,` that give `OTTER_ROLE` when reacted to.
 * `MONGO_URI`: address of the [MongoDB](https://docs.mongodb.com/manual/reference/connection-string/) instance to be used, could be local or [Cluster from Atlas](https://www.mongodb.com/cloud/atlas).
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
     restart: unless-stopped
     environment:
       DISCORD_TOKEN: "${DISCORD_TOKEN}"
-      WELCOME_MESSAGES: "${WELCOME_MESSAGES}"
       MONGO_URI: "mongodb://${MONGO_USERNAME}:${MONGO_PASSWORD}@mongodb:27017/OtterBuddy"
     volumes:
       - ./:/otter-buddy

--- a/otter_welcome_buddy/__main__.py
+++ b/otter_welcome_buddy/__main__.py
@@ -7,6 +7,7 @@ from discord.ext.commands import Bot
 from discord.ext.commands import when_mentioned_or
 from dotenv import load_dotenv
 
+from otter_welcome_buddy.cogs.roles import Roles
 from otter_welcome_buddy.common.constants import ALL_DIRS
 from otter_welcome_buddy.common.constants import COMMAND_PREFIX
 from otter_welcome_buddy.common.constants import LOG_FILE_PATH
@@ -52,6 +53,7 @@ async def main() -> None:
 
     async with bot:
         await database.init_database()
+        Roles.init_welcome_messages()
         await cogs.register_cogs(bot)
         await bot.start(os.environ["DISCORD_TOKEN"])
 

--- a/otter_welcome_buddy/common/constants.py
+++ b/otter_welcome_buddy/common/constants.py
@@ -33,3 +33,5 @@ OTTER_MODERATOR: str = "Collaborator"
 # Discord role that give access to the remaining channels and is
 # given when the user react to WELCOME_MESSAGES
 OTTER_ROLE: str = "Interviewee"
+
+WELCOME_MESSAGES: dict[int, list[int]] = {}

--- a/otter_welcome_buddy/settings.py
+++ b/otter_welcome_buddy/settings.py
@@ -1,10 +1,6 @@
-from os import getenv
-
 from dotenv import load_dotenv
 
 load_dotenv()
 
 
 BOT_TIMEZONE: str = "America/Mexico_City"
-
-WELCOME_MESSAGES = getenv("WELCOME_MESSAGES", "").split(",")

--- a/tests/cogs/test_events.py
+++ b/tests/cogs/test_events.py
@@ -51,7 +51,7 @@ async def test_onReady_printMessage(
 
 
 @pytest.mark.asyncio
-@patch("otter_welcome_buddy.cogs.events.WELCOME_MESSAGES", new=["111"])
+@patch("otter_welcome_buddy.cogs.events.WELCOME_MESSAGES", new={111: [111]})
 async def test_onRawReactionAdd_addRole(
     mocker: MockFixture,
     mock_bot: Bot,


### PR DESCRIPTION
# Description

### Context
Currently giving the base role (`OTTER_ROLE`) depends on an ENV variable when a user reacts to the message, that approach is not extensible to other guilds and other channels, and is not maintainable in the time. Because of that we're migrating the configuration to the database.

### This diff
* Update `on_raw_reaction_add` event to use the database data

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

Updated unit tests and manually tested on a test server

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
