### PR TITLE
english_club_reminder cog implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,8 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+credentials.json
+token.json
 
 # Spyder project settings
 .spyderproject

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 default_language_version:
   # force all unspecified python hooks to run python3
-  python: python3
+  python: python3.10
 
 repos:
   - repo: https://github.com/asottile/pyupgrade

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ You need the following environmental variables either in a `.env` file under the
 
 * `DISCORD_TOKEN`: the Discord Bot Token retrieved from the [developer page](https://discord.com/developers/applications).
 * `MONGO_URI`: address of the [MongoDB](https://docs.mongodb.com/manual/reference/connection-string/) instance to be used, could be local or [Cluster from Atlas](https://www.mongodb.com/cloud/atlas).
+* `ROOT_CHANNEL_ID`: the english-non-teachers channel ID.
+* `GENERAL_CHANNEL_ID`: the english-club channel ID.
+* `ADMIN_ROLE_ID`: ROOT role ID.
+* `COLLABORATOR_ROLE_ID`: Collaborator role ID.
 
 
 <!-- DOCKER INSTRUCTIONS -->

--- a/otter_welcome_buddy/cogs/english_club_reminder.py
+++ b/otter_welcome_buddy/cogs/english_club_reminder.py
@@ -1,0 +1,139 @@
+import re
+
+import discord
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from discord import TextChannel
+from discord.ext import commands
+from discord.ext.commands import Bot
+from discord.ext.commands import Context
+
+from otter_welcome_buddy.common.constants import CronExpressions
+from otter_welcome_buddy.common.constants import OTTER_ADMIN
+from otter_welcome_buddy.common.constants import OTTER_HEADER_IMAGE
+from otter_welcome_buddy.common.constants import OTTER_MODERATOR
+from otter_welcome_buddy.common.utils.dates import DateUtils
+from otter_welcome_buddy.common.utils.discord_ import get_channel_by_id
+from otter_welcome_buddy.common.utils.types.common import DiscordChannelType
+from otter_welcome_buddy.formatters import messages
+from otter_welcome_buddy.settings import ADMIN_ROLE_ID
+from otter_welcome_buddy.settings import COLLABORATOR_ROLE_ID
+from otter_welcome_buddy.settings import ENGLISH_CHANNEL_ID
+from otter_welcome_buddy.settings import NON_ENGLISH_TEACHERS_CHANNEL_ID
+
+ENGLISH_CLUB_JOB_ID = "0a0575d5-ef2e-4269-acc5-07beb53d1ef0"
+
+
+class English(commands.Cog):
+    """
+    English command events, where notifications about English sessions
+    Commands:
+        englishclub start:               Start cronjob for english club reminders messages
+        englishclub stop:                Stop cronjob for english club reminders messages
+
+    schedule_session:    Allows us to schedule an English session
+    """
+
+    def __init__(self, bot: Bot, messages_dependency: type[messages.Formatter]):
+        self.bot: Bot = bot
+        self.messages_formatter: type[messages.Formatter] = messages_dependency
+        self.scheduler: AsyncIOScheduler = AsyncIOScheduler()
+        self.__configure_scheduler()
+
+    @commands.group(
+        brief="Commands related to English Club!",
+        invoke_without_command=True,
+        pass_context=True,
+    )
+    @commands.has_any_role(OTTER_ADMIN, OTTER_MODERATOR)
+    async def englishclub(self, ctx: Context) -> None:
+        """Displays englishclub commands"""
+        await ctx.send_help(ctx.command)
+
+    @englishclub.command(brief="Start the cronjob for the messages")  # type: ignore
+    @commands.has_any_role(OTTER_ADMIN, OTTER_MODERATOR)
+    async def start(self, _: Context) -> None:
+        """Command to interact with the bot and start cron"""
+
+        self.__configure_scheduler()
+
+    @englishclub.command(brief="Stop the cronjob for the messages")  # type: ignore
+    @commands.has_any_role(OTTER_ADMIN, OTTER_MODERATOR)
+    async def stop(self, _: Context) -> None:
+        """Command to interact with the bot and stop cron"""
+
+        self.scheduler.remove_job(ENGLISH_CLUB_JOB_ID)
+
+    @commands.command(brief="Schedule an English session")
+    @commands.has_any_role(OTTER_ADMIN, OTTER_MODERATOR)
+    async def schedule_session(self, ctx: Context, *hour: str) -> None:
+        """Schedules the English Club session"""
+
+        # Regex pattern explanation:
+        # ^: Asserts the start of the string.
+        # (1[0-2]|0?[1-9]): Matches an hour with the 12-hour format.
+        # : Matches the colon that separates the hour and minute.
+        # ([0-5][0-9]): Matches exactly 2 digits for the minutes, from "00" to "59".
+        #  ?: Matches zero or one space, allowing for space between the minutes and AM/PM.
+        # (AM|PM): Matches either "AM" or "PM" (case-sensitive).
+        # $: Asserts the end of the string.
+        time_format_regex = r"^(1[0-2]|0?[1-9]):([0-5][0-9]) ?(AM|PM)$"
+        hour_str: str = " ".join(hour)
+
+        if re.match(time_format_regex, hour_str):
+            channel_id: int = ENGLISH_CHANNEL_ID
+            channel: DiscordChannelType | None = get_channel_by_id(self.bot, channel_id)
+            everyone = "@everyone"
+
+            embed = discord.Embed(
+                colour=discord.Colour.green(),
+                title="English Club Session",
+                description=everyone + self.messages_formatter.english_club_message(hour_str),
+            )
+
+            embed.set_thumbnail(url=OTTER_HEADER_IMAGE)
+
+            if isinstance(channel, TextChannel):
+                await channel.send(embed=embed)
+        else:
+            await ctx.send(
+                "Invalid, Use the following format: HH:MM AM or HH:MM PM, e.g., '10:00 PM'.",
+            )
+
+    def _message_non_english_club(self) -> str:
+        """
+        Generates a message for the English Club reminder.
+        """
+        adm = ADMIN_ROLE_ID
+        col = COLLABORATOR_ROLE_ID
+        description = f"{self.messages_formatter.non_english_club_message()} <@&{adm}> <@&{col}> 👀"
+
+        return description
+
+    def __configure_scheduler(self) -> None:
+        """Configure and start scheduler"""
+
+        self.scheduler.add_job(
+            self._send_message_on_english_non_teachers,
+            DateUtils.create_cron_trigger_from(
+                CronExpressions.WEDNESDAY_NOON_CRON.value,
+            ),
+            id=ENGLISH_CLUB_JOB_ID,
+        )
+        self.scheduler.start()
+
+    async def _send_message_on_english_non_teachers(self) -> None:
+        """
+        Sends message to english_non_teachers channel
+        """
+
+        channel_id: int = NON_ENGLISH_TEACHERS_CHANNEL_ID
+        channel: DiscordChannelType | None = get_channel_by_id(self.bot, channel_id)
+        if isinstance(channel, TextChannel):
+            await channel.send(self._message_non_english_club())
+        else:
+            raise TypeError("Not valid channel to send the message in")
+
+
+async def setup(bot: Bot) -> None:
+    """Set up"""
+    await bot.add_cog(English(bot, messages.Formatter))

--- a/otter_welcome_buddy/cogs/english_club_reminder.py
+++ b/otter_welcome_buddy/cogs/english_club_reminder.py
@@ -87,7 +87,7 @@ class English(commands.Cog):
             embed = discord.Embed(
                 colour=discord.Colour.green(),
                 title="English Club Session",
-                description=everyone + self.messages_formatter.english_club_message(hour_str),
+                description=f"{everyone} {self.messages_formatter.english_club_message(hour_str)}",
             )
 
             embed.set_thumbnail(url=OTTER_HEADER_IMAGE)

--- a/otter_welcome_buddy/common/constants.py
+++ b/otter_welcome_buddy/common/constants.py
@@ -6,6 +6,7 @@ class CronExpressions(Enum):
     """Defined Cron Expressions"""
 
     DAY_ONE_OF_EACH_MONTH_CRON: str = "0 0 1 * *"
+    WEDNESDAY_NOON_CRON: str = "0 12 * * 2"
 
 
 COMMAND_PREFIX: str = "!"
@@ -33,5 +34,7 @@ OTTER_MODERATOR: str = "Collaborator"
 # Discord role that give access to the remaining channels and is
 # given when the user react to WELCOME_MESSAGES
 OTTER_ROLE: str = "Interviewee"
+
+OTTER_HEADER_IMAGE: str = "https://avatars.githubusercontent.com/u/58794037?s=200&v=4"
 
 WELCOME_MESSAGES: dict[int, list[int]] = {}

--- a/otter_welcome_buddy/common/utils/discord_.py
+++ b/otter_welcome_buddy/common/utils/discord_.py
@@ -1,7 +1,10 @@
 import logging
 
 import discord
+from discord.ext.commands import Bot
 from discord.ext.commands import Context
+
+from otter_welcome_buddy.common.utils.types.common import DiscordChannelType
 
 
 logger = logging.getLogger(__name__)
@@ -15,3 +18,10 @@ async def send_plain_message(ctx: Context, message: str) -> None:
         logger.exception("Not enough permissions to send the message")
     except discord.HTTPException:
         logger.exception("Sending the message failed")
+
+
+def get_channel_by_id(bot: Bot, channel_id: int) -> DiscordChannelType | None:
+    """
+    Function to get the a channel by ID
+    """
+    return bot.get_channel(channel_id) if channel_id else None

--- a/otter_welcome_buddy/formatters/messages.py
+++ b/otter_welcome_buddy/formatters/messages.py
@@ -5,3 +5,23 @@ class Formatter:
     def welcome_message() -> str:
         """Message when a new user joins the discord"""
         return "Welcome to Proyecto Nutria"
+
+    @staticmethod
+    def non_english_club_message() -> str:
+        """Message ask English session"""
+        return "Hey yo, English club this week? "
+
+    @staticmethod
+    def english_club_message(hour: str) -> str:
+        """Message when an English session has been scheduled"""
+        message = f"""
+        📣 Join us for an exciting English Club session next Sunday at {hour} Pacific Time! 🕗🌟
+
+        🗓️ Mark your calendars and set a reminder to join us. Don't miss out on the chance
+
+        to improve your language skills and connect with fellow language enthusiasts!
+
+        See you there on the English Club channel! 🎭
+        """
+
+        return message

--- a/otter_welcome_buddy/settings.py
+++ b/otter_welcome_buddy/settings.py
@@ -1,6 +1,14 @@
+import os
+from os import getenv
+
 from dotenv import load_dotenv
 
 load_dotenv()
 
 
 BOT_TIMEZONE: str = "America/Mexico_City"
+WELCOME_MESSAGES = getenv("WELCOME_MESSAGES", "").split(",")
+ADMIN_ROLE_ID: str = os.environ["ADMIN_ROLE_ID"]
+COLLABORATOR_ROLE_ID: str = os.environ["COLLABORATOR_ROLE_ID"]
+ENGLISH_CHANNEL_ID: int = int(os.environ["GENERAL_CHANNEL_ID"])
+NON_ENGLISH_TEACHERS_CHANNEL_ID: int = int(os.environ["ROOT_CHANNEL_ID"])

--- a/otter_welcome_buddy/startup/cogs.py
+++ b/otter_welcome_buddy/startup/cogs.py
@@ -3,6 +3,7 @@ from types import ModuleType  # pylint: disable=no-name-in-module
 
 from discord.ext.commands import Bot
 
+from otter_welcome_buddy.cogs import english_club_reminder
 from otter_welcome_buddy.cogs import events
 from otter_welcome_buddy.cogs import hiring_timelines
 from otter_welcome_buddy.cogs import interview_match
@@ -28,6 +29,7 @@ async def register_cogs(bot: Bot) -> None:
         hiring_timelines,
         interview_match,
         roles,
+        english_club_reminder,
     ]
 
     for cog in allowed_cogs:


### PR DESCRIPTION
# Description

This pull request introduces new functionality to automate weekly communication with the english_non_teachers channel on our Discord server. The aim is to inquire if there will be an English session. The process is as follows:

Every Wednesday at 12:00 PM Pacific Time, a scheduled message will be sent to the english_non_teachers channel.

If a ROOT member or a Collaborator respond to the bot with the command "!schedule_session [time in PT]", an announcement will be made in the english-club channel, notifying everyone about the upcoming session on Sunday at the scheduled time.

Implemented Commands (exclusive to Collaborators):

- `!english start`: Starts the automated communication process.
- `!english stop`: Stops the automated communication process.
- `!schedule_session`: Schedules an English session.

In the **.env** document, the following constants are defined:

- `DISCORD_TOKEN`: Server token for authentication.
- `ROOT_CHANNEL_ID`: Channel ID for "english_non_teachers."
- `GENERAL_CHANNEL_ID`: Channel ID for "english-club."
- `ADMIN_ROLE_ID`: ROOT role ID.
- `COLLABORATOR_ROLE_ID`: Collaborator role ID.


Scheduled message for **english_non_teachers** channel:
![Alt Text](https://media.discordapp.net/attachments/1160427026839257133/1203512187579011072/Screenshot_2024-02-03_at_5.27.07_PM.png?ex=65d15d11&is=65bee811&hm=a35cdf3b4f18b1e9473e2ebc7b47bb2d30ad97ecc5c754feca52a263a072de55&=&format=webp&quality=lossless&width=2020&height=200)


Announcement for **english-club** channel:
![Alt Text](https://media.discordapp.net/attachments/1160427026839257133/1203512187285667890/Screenshot_2024-02-03_at_5.27.22_PM.png?ex=65d15d11&is=65bee811&hm=d40af3a41c1656c6b23814b41a1c9055489c3c51030fd7a6b7e365d0b3b62498&=&format=webp&quality=lossless&width=2160&height=1112)

# Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update


# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
