### PR TITLE
Akotadi/add default users interview match

### DIFF
--- a/otter_welcome_buddy/cogs/interview_match.py
+++ b/otter_welcome_buddy/cogs/interview_match.py
@@ -198,9 +198,17 @@ class InterviewMatch(commands.Cog):
                 placeholder: discord.Member
                 channel, cache_message, placeholder = fetched_values
 
+                # Process default users
+                default_members: list[discord.Member] = []
+                for user_id in entry.default_users or []:
+                    member = channel.guild.get_member(user_id)
+                    if member is not None and not member.bot:
+                        default_members.append(member)
+
                 week_otter_pool: list[discord.Member] = await self._get_weekly_pool(
                     message=cache_message,
                     emoji=entry.emoji,
+                    default_members=default_members,
                 )
                 if not week_otter_pool:
                     await channel.send("No one wanted to practice 😟")
@@ -253,6 +261,7 @@ class InterviewMatch(commands.Cog):
         self,
         message: discord.Message,
         emoji: str,
+        default_members: list[discord.Member],
     ) -> list[discord.Member]:
         week_otter_pool_unique: set[discord.Member] = set()
         for reaction in message.reactions:
@@ -263,6 +272,10 @@ class InterviewMatch(commands.Cog):
                 # no longer belongs to the guild so we don't want to include it
                 if isinstance(user, discord.Member) and not user.bot:
                     week_otter_pool_unique.add(user)
+
+        # Add default users
+        for member in default_members:
+            week_otter_pool_unique.add(member)
 
         week_otter_pool: list[discord.Member] = list(
             week_otter_pool_unique,
@@ -343,14 +356,15 @@ class InterviewMatch(commands.Cog):
 
     @interview_match.command(  # type: ignore
         brief="Start interview match activity",
-        usage="<text_channel> [day_of_week]",
+        usage="<text_channel> [day_of_week] [default_users...]",
     )
     @commands.has_any_role(OTTER_ADMIN, OTTER_MODERATOR)
-    async def start(
+    async def start(  # pylint: disable=keyword-arg-before-vararg
         self,
         ctx: Context,
         channel: discord.TextChannel,
         day_of_week: int = _DEFAULT_DAY_OF_THE_WEEK,
+        *default_users: discord.Member,
     ) -> None:
         """
         Start Interview Match setting up options
@@ -392,6 +406,7 @@ class InterviewMatch(commands.Cog):
             day_of_the_week=day_of_week % 7,
             emoji=emoji_selected,
             message_id=None,
+            default_users=[user.id for user in default_users],
         )
 
         try:

--- a/otter_welcome_buddy/database/models/external/interview_match_model.py
+++ b/otter_welcome_buddy/database/models/external/interview_match_model.py
@@ -1,6 +1,7 @@
 from mongoengine import CASCADE
 from mongoengine import Document
 from mongoengine import IntField
+from mongoengine import ListField
 from mongoengine import ReferenceField
 from mongoengine import StringField
 
@@ -18,6 +19,7 @@ class InterviewMatchModel(Document):
         day_of_the_week (int):  Number identifying where the activity is run where 0 is Sunday
         emoji (str):            Emoji that should be used to react to take part of the activity
         message_id (int):       Identifier of the message that will be processed for the activity
+        default_users (list):   List of user IDs that are always included in the pool
     """
 
     guild = ReferenceField(GuildModel, reverse_delete_rule=CASCADE, primary_key=True)
@@ -26,5 +28,6 @@ class InterviewMatchModel(Document):
     day_of_the_week = IntField(required=True)
     emoji = StringField()
     message_id = IntField()
+    default_users = ListField(IntField())
 
     meta = {"indexes": [{"fields": ["day_of_the_week"]}]}

--- a/tests/database/handlers/test_db_interview_match_handler.py
+++ b/tests/database/handlers/test_db_interview_match_handler.py
@@ -19,6 +19,7 @@ def test_get_interview_match_succeed(
         author_id=123,
         channel_id=123,
         day_of_the_week=0,
+        default_users=[456, 789],
     )
     mocked_interview_match_model.save()
 
@@ -28,6 +29,7 @@ def test_get_interview_match_succeed(
     # Assert
     assert result is not None
     assert result.guild.id == mocked_guild_id
+    assert result.default_users == [456, 789]
 
 
 def test_get_interview_match_not_found(temporary_mongo_connection: MongoClient) -> None:
@@ -49,6 +51,7 @@ def test_insert_interview_match_succeed(
         author_id=123,
         channel_id=123,
         day_of_the_week=0,
+        default_users=[456, 789],
     )
 
     # Act
@@ -59,6 +62,7 @@ def test_insert_interview_match_succeed(
     # Assert
     assert result is not None
     assert result.guild.guild_id == mocked_guild_id
+    assert result.default_users == [456, 789]
 
 
 def test_insert_interview_match_failed(temporary_mongo_connection: MongoClient) -> None:
@@ -83,6 +87,7 @@ def test_delete_interview_match_valid_id(
         author_id=123,
         channel_id=123,
         day_of_the_week=0,
+        default_users=[456, 789],
     )
     mocked_interview_match_model.save()
 


### PR DESCRIPTION
- Add default_users field to InterviewMatchModel
- Modify start command to accept default users
- Include default users in weekly pool processing

## Description
Adds functionality to include default users in the interview match activity pool, even if they don't react to the message.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- Code compiles without syntax errors
- Database model updated with new field
- Command modified to accept default users
- Pool processing includes default users

## Checklist:
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
